### PR TITLE
build(deps): upgrade prettier and ignore README.md

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+README.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/node": "^22.9",
         "@vscode/vsce": "^2.29.0",
         "mocha": "^10.8.2",
-        "prettier": "^3.3.3",
+        "prettier": "^3.6.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.6.3"
       },
@@ -2567,10 +2567,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -69,10 +69,10 @@
   "devDependencies": {
     "@types/mocha": "^10.0.9",
     "@types/node": "^22.9",
+    "@vscode/vsce": "^2.29.0",
     "mocha": "^10.8.2",
-    "prettier": "^3.3.3",
+    "prettier": "^3.6.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.6.3",
-    "@vscode/vsce": "^2.29.0"
+    "typescript": "^5.6.3"
   }
 }


### PR DESCRIPTION
Upgrade prettier to its latest version.
Add .prettierignore to exclude README.md from formatting.
All tests passed after the upgrade.

+~*~+~*~+~*~+~*~+~*~+~*~+~*~+~*~+
The code now shines, a prettier sight,
With every line, aligned and bright.
No audit issues, all clear and free,
A perfect build for all to see.
+~*~+~*~+~*~+~*~+~*~+~*~+~*~+~*~+
