### PR TITLE
feat(datetime): Introduce MyDateTime class for date manipulation

### DIFF
--- a/server/src/MyDateTime.test.ts
+++ b/server/src/MyDateTime.test.ts
@@ -1,0 +1,44 @@
+import { strict as assert } from "assert";
+import { MyDateTime } from "./MyDateTime";
+
+describe("MyDateTime", () => {
+  describe("constructor", () => {
+    it("initializes with the given date string", () => {
+      const date = new MyDateTime("2024-01-01");
+      assert.equal(date.format("YYYY-MM-DD"), "2024-01-01");
+    });
+  });
+
+  describe("#add", () => {
+    context("when unit is 'day'", () => {
+      it("adds days", () => {
+        const date = new MyDateTime("2024-01-01");
+        const newDate = date.add(1, "day");
+        assert.equal(newDate.format("YYYY-MM-DD"), "2024-01-02");
+      });
+    });
+
+    context("when unit is 'month'", () => {
+      it("adds months", () => {
+        const date = new MyDateTime("2024-01-01");
+        const newDate = date.add(1, "month");
+        assert.equal(newDate.format("YYYY-MM-DD"), "2024-02-01");
+      });
+    });
+
+    context("when unit is 'year'", () => {
+      it("adds years", () => {
+        const date = new MyDateTime("2024-01-01");
+        const newDate = date.add(1, "year");
+        assert.equal(newDate.format("YYYY-MM-DD"), "2025-01-01");
+      });
+    });
+  });
+
+  describe("#format", () => {
+    it("formats the date according to the given pattern", () => {
+      const date = new MyDateTime("2024-01-01");
+      assert.equal(date.format("YYYY/MM/DD"), "2024/01/01");
+    });
+  });
+});

--- a/server/src/MyDateTime.ts
+++ b/server/src/MyDateTime.ts
@@ -1,0 +1,52 @@
+import * as dayjs from "dayjs";
+
+export class MyDateTime {
+  private dayjsInstance: dayjs.Dayjs;
+
+  /**
+   * Initializes a new MyDateTime instance.
+   *
+   * @param date - The date to wrap. Can be:
+   *   - a date string
+   *
+   *   If omitted, the current date and time will be used.
+   */
+  constructor(date?: string | number | Date | dayjs.Dayjs) {
+    this.dayjsInstance = dayjs(date);
+  }
+
+  add(value: number, unit: string): MyDateTime {
+    return new MyDateTime(
+      this.dayjsInstance.add(value, convertToDayJsUnit(unit)),
+    );
+  }
+
+  format(formatString: string): string {
+    return this.dayjsInstance.format(formatString);
+  }
+}
+
+/**
+ * Converts a string unit to a dayjs ManipulateType.
+ * @param unit - The unit string (e.g., 'day', 'month', 'year').
+ * @returns The corresponding dayjs ManipulateType.
+ * @throws Error if the unit is unsupported.
+ */
+/**
+ * Converts a string unit to a dayjs ManipulateType.
+ * @param unit - The unit string (e.g., 'day', 'month', 'year').
+ * @returns The corresponding dayjs ManipulateType.
+ * @throws Error if the unit is unsupported.
+ */
+function convertToDayJsUnit(unit: string): dayjs.ManipulateType {
+  switch (unit) {
+    case "day":
+      return "day";
+    case "month":
+      return "month";
+    case "year":
+      return "year";
+    default:
+      throw new Error(`Unsupported unit: ${unit}`);
+  }
+}

--- a/server/src/dateutils.ts
+++ b/server/src/dateutils.ts
@@ -1,5 +1,5 @@
 import { CompletionItem, CompletionItemKind } from "vscode-languageserver";
-import * as dayjs from "dayjs";
+import { MyDateTime } from "./MyDateTime";
 
 export function dateDiffString(diff: number): string {
   let dateDescription = "";
@@ -18,12 +18,12 @@ export function dateDiffString(diff: number): string {
 }
 
 export function createCompletionItem(
-  today: dayjs.Dayjs,
+  today: MyDateTime,
   diff: number,
-  dayjsFormat: string,
+  datetimeFormat: string,
 ): CompletionItem {
   const day = today.add(diff, "day");
-  const label = day.format(dayjsFormat);
+  const label = day.format(datetimeFormat);
   const documentation = [day.format("dddd"), dateDiffString(diff)].join("\n");
   return {
     label,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -15,7 +15,7 @@ import {
   DateStringsConfigurations,
   defaultDateStringsConfigurations,
 } from "./configuration";
-import * as dayjs from "dayjs";
+import { MyDateTime } from "./MyDateTime";
 
 let connection = createConnection(ProposedFeatures.all);
 let documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
@@ -91,7 +91,9 @@ async function createSuggestList(uri: string): Promise<CompletionItem[]> {
   if (settings == undefined) return [] as CompletionItem[];
 
   const dateDiffRange = range(settings.maxDaysBefore, settings.maxDaysAfter);
-  const today = dayjs(settings.today === "" ? undefined : settings.today);
+  const today = new MyDateTime(
+    settings.today === "" ? undefined : settings.today,
+  );
   return dateDiffRange.map((diff) =>
     createCompletionItem(today, diff, settings.dateFormat),
   );


### PR DESCRIPTION
This commit introduces a new MyDateTime class to encapsulate date manipulation logic,
replacing direct dayjs usage in server/src/dateutils.ts and server/src/server.ts.
This refactoring improves code organization and testability.

* * *
A new class, MyDateTime, now takes its place,
Encapsulating time, with elegant grace.
No longer dayjs, directly in sight,
But through MyDateTime, all dates shine bright.
* * *
